### PR TITLE
[api,web] feat: 소환사의 gameName과 tagLine 만으로 실시간 게임 정보를 조회할 수 있도록 api 통합

### DIFF
--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -12,21 +12,15 @@ export class AppController {
     return 'Hello World!';
   }
 
-  @Get('summoner')
-  async getSummoner(
+  @Get('current-game')
+  async getCurrentGame(
     @Query('gameName') gameName: string,
     @Query('tagLine') tagLine: string,
   ) {
-    const getSummonerRequestDto = GetSummonerRequestDto.create(
+    const getCurrentGameRequestDto = GetCurrentGameRequestDto.create(
       gameName,
       tagLine,
     );
-    return this.appService.searchSummoner(getSummonerRequestDto);
-  }
-
-  @Get('current-game')
-  async getCurrentGame(@Query('puuid') puuid: string) {
-    const getCurrentGameRequestDto = GetCurrentGameRequestDto.create(puuid);
     return this.appService.checkCurrentGame(getCurrentGameRequestDto);
   }
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule } from '@nestjs/config';
+import { RiotModule } from './riot/riot.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
     }),
+    RiotModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/app.service.spec.ts
+++ b/apps/api/src/app.service.spec.ts
@@ -1,27 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ConfigService } from '@nestjs/config';
 import { AppService } from './app.service';
-import {
-  GetSummonerRequestDto,
-  GetSummonerResponseDto,
-} from './dto/get-summoner.dto';
+import { RiotService } from './riot/riot.service';
 
 describe('AppService', () => {
   let service: AppService;
 
-  const mockConfigService = {
-    get: jest.fn((key: string) => {
-      switch (key) {
-        case 'RIOT_API_KEY':
-          return 'test-api-key';
-        case 'RIOT_API_ASIA_BASE_URL':
-          return 'https://test-api.url';
-        case 'RIOT_API_KR_BASE_URL':
-          return 'https://test-api.url';
-        default:
-          return null;
-      }
-    }),
+  const mockRiotService: Partial<RiotService> = {
+    searchSummoner: jest.fn(),
+    checkCurrentGame: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -29,8 +15,8 @@ describe('AppService', () => {
       providers: [
         AppService,
         {
-          provide: ConfigService,
-          useValue: mockConfigService,
+          provide: RiotService,
+          useValue: mockRiotService,
         },
       ],
     }).compile();
@@ -38,48 +24,7 @@ describe('AppService', () => {
     service = module.get<AppService>(AppService);
   });
 
-  describe('searchSummoner', () => {
-    let fetchMock: jest.SpyInstance;
-
-    beforeEach(() => {
-      fetchMock = jest.spyOn(global, 'fetch').mockImplementation();
-    });
-
-    afterEach(() => {
-      fetchMock.mockRestore();
-    });
-
-    it('소환사 정보를 성공적으로 검색해야 합니다', async () => {
-      const mockResponse: GetSummonerResponseDto =
-        GetSummonerResponseDto.create('test-puuid');
-
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve(mockResponse),
-      } as Response);
-
-      const result = await service.searchSummoner(
-        GetSummonerRequestDto.create('TestUser', 'KR1'),
-      );
-
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://test-api.url/riot/account/v1/accounts/by-riot-id/TestUser/KR1',
-        {
-          headers: {
-            'X-Riot-Token': 'test-api-key',
-          },
-        },
-      );
-      expect(result.puuid).toEqual(mockResponse.puuid);
-    });
-
-    it('API 호출 실패시 에러를 처리해야 합니다', async () => {
-      fetchMock.mockRejectedValueOnce(new Error('API 호출 실패'));
-
-      await expect(
-        service.searchSummoner(GetSummonerRequestDto.create('TestUser', 'KR1')),
-      ).rejects.toThrow('API 호출 실패');
-    });
+  it('should be defined', () => {
+    expect(service).toBeDefined();
   });
 });

--- a/apps/api/src/app.service.spec.ts
+++ b/apps/api/src/app.service.spec.ts
@@ -5,7 +5,7 @@ import { RiotService } from './riot/riot.service';
 describe('AppService', () => {
   let service: AppService;
 
-  const mockRiotService: Partial<RiotService> = {
+  const mockRiotService: jest.Mocked<Partial<RiotService>> = {
     searchSummoner: jest.fn(),
     checkCurrentGame: jest.fn(),
   };
@@ -26,5 +26,27 @@ describe('AppService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('search current game', () => {
+    it('소환사의 gameName과 tagLine을 받아 현재 게임을 찾을 수 있어야 한다.', async () => {
+      const mockGameName = 'test-gameName';
+      const mockTagLine = 'test-tagLine';
+      const mockCurrentGame = {
+        gameId: 'test-gameId',
+      };
+
+      mockRiotService.searchSummoner.mockResolvedValue({
+        puuid: 'test-puuid',
+      });
+
+      mockRiotService.checkCurrentGame.mockResolvedValue(mockCurrentGame);
+      const result = await service.checkCurrentGame({
+        gameName: mockGameName,
+        tagLine: mockTagLine,
+      });
+
+      expect(result).toEqual(mockCurrentGame);
+    });
   });
 });

--- a/apps/api/src/app.service.ts
+++ b/apps/api/src/app.service.ts
@@ -1,90 +1,17 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import {
-  GetSummonerRequestDto,
-  GetSummonerResponseDto,
-} from './dto/get-summoner.dto';
+import { Injectable } from '@nestjs/common';
+import { GetSummonerRequestDto } from './dto/get-summoner.dto';
 import { GetCurrentGameRequestDto } from './dto/get-current-game.dto';
+import { RiotService } from './riot/riot.service';
 
 @Injectable()
 export class AppService {
-  private riotApiAsiaBaseUrl: string;
-  private riotApiKrBaseUrl: string;
-  private lolDataDragonBaseUrl: string;
-  private riotApiKey: string;
+  constructor(private riotService: RiotService) {}
 
-  constructor(private configService: ConfigService) {
-    this.riotApiKey = this.configService.get('RIOT_API_KEY');
-    this.riotApiAsiaBaseUrl = this.configService.get('RIOT_API_ASIA_BASE_URL');
-    this.riotApiKrBaseUrl = this.configService.get('RIOT_API_KR_BASE_URL');
-    this.lolDataDragonBaseUrl = this.configService.get(
-      'LOL_DATA_DRAGON_BASE_URL',
-    );
+  async searchSummoner({ gameName, tagLine }: GetSummonerRequestDto) {
+    return this.riotService.searchSummoner(gameName, tagLine);
   }
 
-  async searchSummoner(getSummonerRequestDto: GetSummonerRequestDto) {
-    try {
-      const response = await fetch(
-        `${this.riotApiAsiaBaseUrl}/riot/account/v1/accounts/by-riot-id/${getSummonerRequestDto.gameName}/${getSummonerRequestDto.tagLine}`,
-        {
-          headers: {
-            'X-Riot-Token': this.riotApiKey,
-          },
-        },
-      );
-
-      if (!response.ok) {
-        throw new NotFoundException(
-          `Summoner ${getSummonerRequestDto.gameName} ${getSummonerRequestDto.tagLine} not found`,
-        );
-      }
-
-      const data = await response.json();
-      return GetSummonerResponseDto.create(data.puuid);
-    } catch (error) {
-      Logger.debug(error);
-      throw error;
-    }
-  }
-
-  async checkCurrentGame(getCurrentGameRequestDto: GetCurrentGameRequestDto) {
-    try {
-      const response = await fetch(
-        `${this.riotApiKrBaseUrl}/lol/spectator/v5/active-games/by-summoner/${getCurrentGameRequestDto.puuid}`,
-        {
-          headers: {
-            'X-Riot-Token': this.riotApiKey,
-          },
-        },
-      );
-
-      if (!response.ok) {
-        throw new NotFoundException(
-          `Current game of ${getCurrentGameRequestDto.puuid} not found`,
-        );
-      }
-
-      const data = await response.json();
-      return data;
-    } catch (error) {
-      Logger.debug(error);
-      throw error;
-    }
-  }
-
-  // 이후 사용
-  private async getAssetBaseUrl() {
-    const latestVersion = await this.getLatestVersion();
-
-    return `${this.lolDataDragonBaseUrl}/cdn/${latestVersion}/data/ko_KR`;
-  }
-
-  // 이후 사용
-  private async getLatestVersion() {
-    const versionResponse = await fetch(
-      `${this.lolDataDragonBaseUrl}/api/versions.json`,
-    );
-    const data = await versionResponse.json();
-    return data[0];
+  async checkCurrentGame({ puuid }: GetCurrentGameRequestDto) {
+    return this.riotService.checkCurrentGame(puuid);
   }
 }

--- a/apps/api/src/dto/get-current-game.dto.ts
+++ b/apps/api/src/dto/get-current-game.dto.ts
@@ -2,11 +2,15 @@ import { IsString, validate, validateSync } from 'class-validator';
 
 export class GetCurrentGameRequestDto {
   @IsString()
-  puuid: string;
+  gameName: string;
 
-  static create(puuid: string) {
+  @IsString()
+  tagLine: string;
+
+  static create(gameName: string, tagLine: string) {
     const getCurrentGameRequestDto = new GetCurrentGameRequestDto();
-    getCurrentGameRequestDto.puuid = puuid;
+    getCurrentGameRequestDto.gameName = gameName;
+    getCurrentGameRequestDto.tagLine = tagLine;
     validateSync(getCurrentGameRequestDto);
     return getCurrentGameRequestDto;
   }

--- a/apps/api/src/exceptions/exceptions.ts
+++ b/apps/api/src/exceptions/exceptions.ts
@@ -1,0 +1,25 @@
+import { NotFoundException } from '@nestjs/common';
+
+export class SummonerNotFoundException extends NotFoundException {
+  constructor(name: string, tag: string) {
+    super(`summoner ${name}#${tag} not found`);
+  }
+}
+
+export class CurrentGameNotFoundException extends NotFoundException {
+  private constructor(message: string) {
+    super(message);
+  }
+
+  static createByPuuid(puuid: string) {
+    return new CurrentGameNotFoundException(
+      `current game of puuid:${puuid} not found`,
+    );
+  }
+
+  static createByNameAndTag(name: string, tag: string) {
+    return new CurrentGameNotFoundException(
+      `current game of ${name}#${tag} not found`,
+    );
+  }
+}

--- a/apps/api/src/riot/riot.module.ts
+++ b/apps/api/src/riot/riot.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { RiotService } from './riot.service';
+
+@Module({
+  providers: [RiotService],
+  exports: [RiotService],
+})
+export class RiotModule {}

--- a/apps/api/src/riot/riot.service.spec.ts
+++ b/apps/api/src/riot/riot.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RiotService } from './riot.service';
+
+describe('RiotService', () => {
+  let service: RiotService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RiotService],
+    }).compile();
+
+    service = module.get<RiotService>(RiotService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/api/src/riot/riot.service.spec.ts
+++ b/apps/api/src/riot/riot.service.spec.ts
@@ -1,18 +1,126 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RiotService } from './riot.service';
+import { ConfigService } from '@nestjs/config';
+import { NotFoundException } from '@nestjs/common';
 
 describe('RiotService', () => {
   let service: RiotService;
+  let configService: ConfigService;
+  const mockRiotApiKey = 'test-api-key';
+  const mockRiotApiAsiaBaseUrl = 'https://asia.api.riotgames.com';
+  const mockRiotApiKrBaseUrl = 'https://kr.api.riotgames.com';
+  const mockLolDataDragonBaseUrl = 'https://ddragon.leagueoflegends.com';
+
+  const mockConfigService = {
+    get: jest.fn((key: string) => {
+      switch (key) {
+        case 'RIOT_API_KEY':
+          return mockRiotApiKey;
+        case 'RIOT_API_ASIA_BASE_URL':
+          return mockRiotApiAsiaBaseUrl;
+        case 'RIOT_API_KR_BASE_URL':
+          return mockRiotApiKrBaseUrl;
+        case 'LOL_DATA_DRAGON_BASE_URL':
+          return mockLolDataDragonBaseUrl;
+        default:
+          return undefined;
+      }
+    }),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [RiotService],
+      providers: [
+        RiotService,
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
     }).compile();
 
     service = module.get<RiotService>(RiotService);
+    configService = module.get<ConfigService>(ConfigService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('searchSummoner', () => {
+    const mockGameName = 'testUser';
+    const mockTagLine = 'KR1';
+    const mockPuuid = 'test-puuid';
+
+    beforeEach(() => {
+      global.fetch = jest.fn();
+    });
+
+    it('성공적으로 소환사를 검색해야 합니다', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ puuid: mockPuuid }),
+      });
+
+      const result = await service.searchSummoner(mockGameName, mockTagLine);
+
+      expect(result.puuid).toBe(mockPuuid);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `https://asia.api.riotgames.com/riot/account/v1/accounts/by-riot-id/${mockGameName}/${mockTagLine}`,
+        {
+          headers: {
+            'X-Riot-Token': mockRiotApiKey,
+          },
+        },
+      );
+    });
+
+    it('소환사를 찾을 수 없을 때 NotFoundException을 던져야 합니다', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+      });
+
+      await expect(
+        service.searchSummoner(mockGameName, mockTagLine),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('checkCurrentGame', () => {
+    const mockPuuid = 'test-puuid';
+    const mockGameData = { gameId: '123456' };
+
+    beforeEach(() => {
+      global.fetch = jest.fn();
+    });
+
+    it('성공적으로 현재 게임을 조회해야 합니다', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockGameData),
+      });
+
+      const result = await service.checkCurrentGame(mockPuuid);
+
+      expect(result).toEqual(mockGameData);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `https://kr.api.riotgames.com/lol/spectator/v5/active-games/by-summoner/${mockPuuid}`,
+        {
+          headers: {
+            'X-Riot-Token': mockRiotApiKey,
+          },
+        },
+      );
+    });
+
+    it('현재 게임을 찾을 수 없을 때 NotFoundException을 던져야 합니다', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+      });
+
+      await expect(service.checkCurrentGame(mockPuuid)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
   });
 });

--- a/apps/api/src/riot/riot.service.ts
+++ b/apps/api/src/riot/riot.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GetSummonerResponseDto } from '../dto/get-summoner.dto';
+
+@Injectable()
+export class RiotService {
+  private riotApiAsiaBaseUrl: string;
+  private riotApiKrBaseUrl: string;
+  private lolDataDragonBaseUrl: string;
+  private riotApiKey: string;
+
+  constructor(private configService: ConfigService) {
+    this.riotApiKey = this.configService.get('RIOT_API_KEY');
+    this.riotApiAsiaBaseUrl = this.configService.get('RIOT_API_ASIA_BASE_URL');
+    this.riotApiKrBaseUrl = this.configService.get('RIOT_API_KR_BASE_URL');
+    this.lolDataDragonBaseUrl = this.configService.get(
+      'LOL_DATA_DRAGON_BASE_URL',
+    );
+  }
+
+  async searchSummoner(gameName: string, tagLine: string) {
+    try {
+      const response = await fetch(
+        `${this.riotApiAsiaBaseUrl}/riot/account/v1/accounts/by-riot-id/${gameName}/${tagLine}`,
+        {
+          headers: {
+            'X-Riot-Token': this.riotApiKey,
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw new NotFoundException(
+          `Summoner ${gameName} ${tagLine} not found`,
+        );
+      }
+
+      const data = await response.json();
+      return GetSummonerResponseDto.create(data.puuid);
+    } catch (error) {
+      Logger.debug(error);
+      throw error;
+    }
+  }
+
+  async checkCurrentGame(puuid: string) {
+    try {
+      const response = await fetch(
+        `${this.riotApiKrBaseUrl}/lol/spectator/v5/active-games/by-summoner/${puuid}`,
+        {
+          headers: {
+            'X-Riot-Token': this.riotApiKey,
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw new NotFoundException(`Current game of ${puuid} not found`);
+      }
+
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      Logger.debug(error);
+      throw error;
+    }
+  }
+
+  // 이후 사용
+  private async getAssetBaseUrl() {
+    const latestVersion = await this.getLatestVersion();
+
+    return `${this.lolDataDragonBaseUrl}/cdn/${latestVersion}/data/ko_KR`;
+  }
+
+  // 이후 사용
+  private async getLatestVersion() {
+    const versionResponse = await fetch(
+      `${this.lolDataDragonBaseUrl}/api/versions.json`,
+    );
+    const data = await versionResponse.json();
+    return data[0];
+  }
+}

--- a/apps/api/src/riot/riot.service.ts
+++ b/apps/api/src/riot/riot.service.ts
@@ -1,6 +1,10 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GetSummonerResponseDto } from '../dto/get-summoner.dto';
+import {
+  CurrentGameNotFoundException,
+  SummonerNotFoundException,
+} from '../exceptions/exceptions';
 
 @Injectable()
 export class RiotService {
@@ -30,9 +34,7 @@ export class RiotService {
       );
 
       if (!response.ok) {
-        throw new NotFoundException(
-          `Summoner ${gameName} ${tagLine} not found`,
-        );
+        throw new SummonerNotFoundException(gameName, tagLine);
       }
 
       const data = await response.json();
@@ -55,7 +57,7 @@ export class RiotService {
       );
 
       if (!response.ok) {
-        throw new NotFoundException(`Current game of ${puuid} not found`);
+        throw CurrentGameNotFoundException.createByPuuid(puuid);
       }
 
       const data = await response.json();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,11 +1,10 @@
 import { useState } from "react";
-import { checkCurrentGame, findSummonerUuid } from "./fetcher";
+import { checkCurrentGame } from "./fetcher";
 import "./global.css";
 
 function App() {
   const [gameName, setGameName] = useState("");
   const [tagLine, setTagLine] = useState("");
-  const [puuid, setPuuid] = useState("");
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [gameObject, setGameObject] = useState<Record<string, any>>({});
 
@@ -17,24 +16,11 @@ function App() {
     setTagLine(e.target.value);
   };
 
-  const handlePuuidChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPuuid(e.target.value);
-  };
-
-  const handleFindSummonerUuid = async () => {
-    const response = await findSummonerUuid({
-      queryParam: {
-        gameName,
-        tagLine,
-      },
-    });
-    setPuuid(response.puuid);
-  };
-
   const handleCheckCurrentGame = async () => {
     const response = await checkCurrentGame({
       queryParam: {
-        puuid,
+        gameName,
+        tagLine,
       },
     });
     setGameObject(response);
@@ -51,11 +37,7 @@ function App() {
           <span>tagLine</span>
           <input type="text" value={tagLine} onChange={handleTagLineChange} />
         </label>
-        <label>
-          <span>puuid</span>
-          <input type="text" value={puuid} onChange={handlePuuidChange} />
-        </label>
-        <button onClick={handleFindSummonerUuid}>Find Summoner UUID</button>
+
         <button onClick={handleCheckCurrentGame}>Check Current Game</button>
         <div>{JSON.stringify(gameObject)}</div>
       </div>

--- a/apps/web/src/fetcher.ts
+++ b/apps/web/src/fetcher.ts
@@ -2,28 +2,11 @@ import { generateFetcher } from "./utils/api-fetcher/generateFetcher";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
-export const findSummonerUuid = generateFetcher<
+export const checkCurrentGame = generateFetcher<
   void,
   {
     gameName: string;
     tagLine: string;
-  },
-  void,
-  {
-    puuid: string;
-  }
->({
-  base: API_BASE_URL,
-  endpoint: "/summoner",
-  method: "GET",
-  requestContentType: "json",
-  responseContentType: "json",
-});
-
-export const checkCurrentGame = generateFetcher<
-  void,
-  {
-    puuid: string;
   },
   void,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ad4cdf0d-1bb6-4b23-8009-432960150266)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- 신규 기능
	- 게임 이름과 태그라인을 사용해 현재 게임 상태를 조회할 수 있도록 업데이트됨에 따라, 기존에 사용되던 소환사 UUID 방식이 제거되었습니다.
	- 사용자 인터페이스가 간소화되어 입력 필드가 보다 직관적으로 개선되었습니다.
- 리팩토링
	- API 엔드포인트 및 서비스 로직이 개선되어, 데이터 조회 및 오류 처리 시 보다 명확한 피드백을 제공합니다.
- 예외 처리 개선
	- 소환사 및 현재 게임 데이터 조회 실패 시 새로운 예외 클래스가 추가되어 보다 구체적인 오류 처리가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->