### PR TITLE
[api,web] feat: 챔피언, 스펠 이미지 적용하기

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,6 +3,8 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule } from '@nestjs/config';
 import { RiotModule } from './riot/riot.module';
+import { Mapper } from './mapper/mapper';
+import { RiotService } from './riot/riot.service';
 
 @Module({
   imports: [
@@ -12,6 +14,6 @@ import { RiotModule } from './riot/riot.module';
     RiotModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, Mapper],
 })
 export class AppModule {}

--- a/apps/api/src/app.service.ts
+++ b/apps/api/src/app.service.ts
@@ -12,7 +12,10 @@ import { Mapper } from './mapper/mapper';
 
 @Injectable()
 export class AppService {
-  constructor(private riotService: RiotService) {}
+  constructor(
+    private riotService: RiotService,
+    private mapper: Mapper,
+  ) {}
 
   async checkCurrentGame({
     gameName,
@@ -24,7 +27,7 @@ export class AppService {
         summoner.puuid,
       );
 
-      return Mapper.SpectatorV5ResponseDtoToGetCurrentGameResponseDto(
+      return this.mapper.SpectatorV5ResponseDtoToGetCurrentGameResponseDto(
         currentGame,
       );
     } catch (error) {

--- a/apps/api/src/exceptions/exceptions.ts
+++ b/apps/api/src/exceptions/exceptions.ts
@@ -23,3 +23,21 @@ export class CurrentGameNotFoundException extends NotFoundException {
     );
   }
 }
+
+export class ChampionNotFoundException extends NotFoundException {
+  constructor(championId: number) {
+    super(`champion ${championId} not found`);
+  }
+}
+
+export class SummonerSpellNotFoundException extends NotFoundException {
+  constructor(summonerSpellId: number) {
+    super(`summoner spell ${summonerSpellId} not found`);
+  }
+}
+
+export class PerkNotFoundException extends NotFoundException {
+  constructor(perkId: number) {
+    super(`perk ${perkId} not found`);
+  }
+}

--- a/apps/api/src/mapper/mapper.ts
+++ b/apps/api/src/mapper/mapper.ts
@@ -4,6 +4,7 @@ import {
   ChampionJson,
   SpectatorV5ResponseDto,
   Summoner,
+  SummonerSpellJson,
 } from '../riot/riot.dto';
 import { RiotService } from '../riot/riot.service';
 import { Injectable } from '@nestjs/common';
@@ -12,20 +13,22 @@ import { Injectable } from '@nestjs/common';
 export class Mapper {
   private initialized = false;
   private championJson: ChampionJson | null = null;
+  private summonerSpellJson: SummonerSpellJson | null = null;
   private assetBaseUrl: string | null = null;
-
   constructor(private riotService: RiotService) {}
 
   async init() {
     if (this.initialized) {
       return;
     }
-    const [championJson, assetBaseUrl] = await Promise.all([
+    const [championJson, assetBaseUrl, summonerSpellJson] = await Promise.all([
       this.riotService.getChampionJson(),
       this.riotService.getAssetBaseUrl(),
+      this.riotService.getSummonerSpellJson(),
     ]);
     this.championJson = championJson;
     this.assetBaseUrl = assetBaseUrl;
+    this.summonerSpellJson = summonerSpellJson;
     this.initialized = true;
   }
 
@@ -39,19 +42,27 @@ export class Mapper {
     const teamRed = participants
       .filter((participant) => participant.teamId === 100)
       .map((participant) => {
-        const { championId, ...rest } = participant;
+        const { championId, spell1Id, spell2Id, ...rest } = participant;
         return {
           ...rest,
           champion: this.convertChampionIdToChampionModel(championId),
+          spells: [
+            this.convertSummonerSpellIdToSummonerSpellModel(spell1Id),
+            this.convertSummonerSpellIdToSummonerSpellModel(spell2Id),
+          ],
         };
       });
     const teamBlue = participants
       .filter((participant) => participant.teamId === 200)
       .map((participant) => {
-        const { championId, ...rest } = participant;
+        const { championId, spell1Id, spell2Id, ...rest } = participant;
         return {
           ...rest,
           champion: this.convertChampionIdToChampionModel(championId),
+          spells: [
+            this.convertSummonerSpellIdToSummonerSpellModel(spell1Id),
+            this.convertSummonerSpellIdToSummonerSpellModel(spell2Id),
+          ],
         };
       });
 
@@ -80,5 +91,28 @@ export class Mapper {
     };
 
     return championModel;
+  }
+
+  private convertSummonerSpellIdToSummonerSpellModel(
+    summonerSpellId: number,
+  ): Model.SummonerSpell {
+    const summonerSpellJson = this.summonerSpellJson;
+    const assetBaseUrl = this.assetBaseUrl;
+
+    const summonerSpell = Object.values(summonerSpellJson.data).find(
+      (summonerSpell) => summonerSpell.key === summonerSpellId.toString(),
+    );
+
+    const spellModel: Model.SummonerSpell = {
+      id: summonerSpell.id,
+      name: summonerSpell.name,
+      description: summonerSpell.description,
+      key: summonerSpell.key,
+      image: {
+        square: `${assetBaseUrl}/img/spell/${summonerSpell.id}.png`,
+      },
+    };
+
+    return spellModel;
   }
 }

--- a/apps/api/src/mapper/mapper.ts
+++ b/apps/api/src/mapper/mapper.ts
@@ -1,21 +1,84 @@
+import type { Model } from '@are-you-playing-lol/common-interfaces';
 import { GetCurrentGameResponseDto } from '../dto/get-current-game.dto';
-import { SpectatorV5ResponseDto } from '../riot/riot.dto';
+import {
+  ChampionJson,
+  SpectatorV5ResponseDto,
+  Summoner,
+} from '../riot/riot.dto';
+import { RiotService } from '../riot/riot.service';
+import { Injectable } from '@nestjs/common';
 
+@Injectable()
 export class Mapper {
-  static async SpectatorV5ResponseDtoToGetCurrentGameResponseDto(
+  private initialized = false;
+  private championJson: ChampionJson | null = null;
+  private assetBaseUrl: string | null = null;
+
+  constructor(private riotService: RiotService) {}
+
+  async init() {
+    if (this.initialized) {
+      return;
+    }
+    const [championJson, assetBaseUrl] = await Promise.all([
+      this.riotService.getChampionJson(),
+      this.riotService.getAssetBaseUrl(),
+    ]);
+    this.championJson = championJson;
+    this.assetBaseUrl = assetBaseUrl;
+    this.initialized = true;
+  }
+
+  async SpectatorV5ResponseDtoToGetCurrentGameResponseDto(
     spectatorV5ResponseDto: SpectatorV5ResponseDto,
   ): Promise<GetCurrentGameResponseDto> {
-    const teamRed = spectatorV5ResponseDto.participants.filter(
-      (participant) => participant.teamId === 100,
-    );
-    const teamBlue = spectatorV5ResponseDto.participants.filter(
-      (participant) => participant.teamId === 200,
-    );
+    await this.init();
+
+    const { participants, ...rest } = spectatorV5ResponseDto;
+
+    const teamRed = participants
+      .filter((participant) => participant.teamId === 100)
+      .map((participant) => {
+        const { championId, ...rest } = participant;
+        return {
+          ...rest,
+          champion: this.convertChampionIdToChampionModel(championId),
+        };
+      });
+    const teamBlue = participants
+      .filter((participant) => participant.teamId === 200)
+      .map((participant) => {
+        const { championId, ...rest } = participant;
+        return {
+          ...rest,
+          champion: this.convertChampionIdToChampionModel(championId),
+        };
+      });
 
     return GetCurrentGameResponseDto.create({
-      ...spectatorV5ResponseDto,
+      ...rest,
       teamRed,
       teamBlue,
     });
+  }
+
+  private convertChampionIdToChampionModel(championId: number): Model.Champion {
+    const championJson = this.championJson;
+    const assetBaseUrl = this.assetBaseUrl;
+
+    const champion = Object.values(championJson.data).find(
+      (champion) => champion.key === championId.toString(),
+    );
+    const championModel: Model.Champion = {
+      id: champion.id,
+      key: champion.key,
+      name: champion.name,
+      title: champion.title,
+      image: {
+        square: `${assetBaseUrl}/img/champion/${champion.image.full}`,
+      },
+    };
+
+    return championModel;
   }
 }

--- a/apps/api/src/mapper/mapper.ts
+++ b/apps/api/src/mapper/mapper.ts
@@ -41,36 +41,28 @@ export class Mapper {
 
     const teamRed = participants
       .filter((participant) => participant.teamId === 100)
-      .map((participant) => {
-        const { championId, spell1Id, spell2Id, ...rest } = participant;
-        return {
-          ...rest,
-          champion: this.convertChampionIdToChampionModel(championId),
-          spells: [
-            this.convertSummonerSpellIdToSummonerSpellModel(spell1Id),
-            this.convertSummonerSpellIdToSummonerSpellModel(spell2Id),
-          ],
-        };
-      });
+      .map((participant) => this.convertSummonerToSummonerModel(participant));
     const teamBlue = participants
       .filter((participant) => participant.teamId === 200)
-      .map((participant) => {
-        const { championId, spell1Id, spell2Id, ...rest } = participant;
-        return {
-          ...rest,
-          champion: this.convertChampionIdToChampionModel(championId),
-          spells: [
-            this.convertSummonerSpellIdToSummonerSpellModel(spell1Id),
-            this.convertSummonerSpellIdToSummonerSpellModel(spell2Id),
-          ],
-        };
-      });
+      .map((participant) => this.convertSummonerToSummonerModel(participant));
 
     return GetCurrentGameResponseDto.create({
       ...rest,
       teamRed,
       teamBlue,
     });
+  }
+
+  private convertSummonerToSummonerModel(summoner: Summoner): Model.Summoner {
+    const { championId, spell1Id, spell2Id, ...rest } = summoner;
+    return {
+      ...rest,
+      champion: this.convertChampionIdToChampionModel(championId),
+      spells: [
+        this.convertSummonerSpellIdToSummonerSpellModel(spell1Id),
+        this.convertSummonerSpellIdToSummonerSpellModel(spell2Id),
+      ],
+    };
   }
 
   private convertChampionIdToChampionModel(championId: number): Model.Champion {

--- a/apps/api/src/riot/riot.dto.ts
+++ b/apps/api/src/riot/riot.dto.ts
@@ -116,3 +116,25 @@ export interface SummonerSpellData {
   description: string;
   key: string;
 }
+
+export interface RunesReforgedJson
+  extends Array<{
+    id: number;
+    key: string;
+    icon: string;
+    name: string;
+    slots: RuneSlot[];
+  }> {}
+
+export interface RuneSlot {
+  runes: Rune[];
+}
+
+export interface Rune {
+  id: number;
+  key: string;
+  icon: string;
+  name: string;
+  shortDesc: string;
+  longDesc: string;
+}

--- a/apps/api/src/riot/riot.dto.ts
+++ b/apps/api/src/riot/riot.dto.ts
@@ -41,3 +41,78 @@ export interface BannedChampion {
   teamId: number;
   pickTurn: number;
 }
+
+export interface ChampionJson {
+  type: 'champion';
+  format: string;
+  version: string;
+  data: Record<string, ChampionData>;
+}
+
+export interface ChampionData {
+  version: string;
+  id: string;
+  key: string;
+  name: string;
+  title: string;
+  blurb: string;
+  info: ChampionInfo;
+  image: ChampionImage;
+  tags: string[];
+  partype: string;
+  stats: ChampionStats;
+}
+
+export interface ChampionInfo {
+  attack: number;
+  defense: number;
+  magic: number;
+  difficulty: number;
+}
+
+export interface ChampionImage {
+  full: string;
+  sprite: string;
+  group: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface ChampionStats {
+  hp: number;
+  hpperlevel: number;
+  mp: number;
+  mpperlevel: number;
+  movespeed: number;
+  armor: number;
+  armorperlevel: number;
+  spellblock: number;
+  spellblockperlevel: number;
+  attackrange: number;
+  hpregen: number;
+  hpregenperlevel: number;
+  mpregen: number;
+  mpregenperlevel: number;
+  crit: number;
+  critperlevel: number;
+  attackdamage: number;
+  attackdamageperlevel: number;
+  attackspeedperlevel: number;
+  attackspeed: number;
+}
+
+export interface SummonerSpellJson {
+  type: 'summoner';
+  format: string;
+  version: string;
+  data: Record<string, SummonerSpellData>;
+}
+
+export interface SummonerSpellData {
+  id: string;
+  name: string;
+  description: string;
+  key: string;
+}

--- a/apps/api/src/riot/riot.service.ts
+++ b/apps/api/src/riot/riot.service.ts
@@ -18,6 +18,7 @@ export class RiotService {
   private riotApiKrBaseUrl: string;
   private lolDataDragonBaseUrl: string;
   private riotApiKey: string;
+  private locale = 'ko_KR';
 
   constructor(private configService: ConfigService) {
     this.riotApiKey = this.configService.get('RIOT_API_KEY');
@@ -78,12 +79,15 @@ export class RiotService {
     return `${this.lolDataDragonBaseUrl}/cdn`;
   }
 
+  // TODO: 캐시 처리
   async getAssetVersionedBaseUrl() {
+    const assetBaseUrl = await this.getAssetBaseUrl();
     const latestVersion = await this.getLatestVersion();
 
-    return `${this.lolDataDragonBaseUrl}/cdn/${latestVersion}`;
+    return `${assetBaseUrl}/${latestVersion}`;
   }
 
+  // TODO: 캐시 처리
   private async getLatestVersion() {
     const versionResponse = await fetch(
       `${this.lolDataDragonBaseUrl}/api/versions.json`,
@@ -92,28 +96,31 @@ export class RiotService {
     return data[0];
   }
 
+  // TODO: 캐시 처리
   async getChampionJson(): Promise<ChampionJson> {
-    const latestVersion = await this.getLatestVersion();
+    const assetVersionedBaseUrl = await this.getAssetVersionedBaseUrl();
     const response = await fetch(
-      `${this.lolDataDragonBaseUrl}/cdn/${latestVersion}/data/ko_KR/champion.json`,
+      `${assetVersionedBaseUrl}/data/${this.locale}/champion.json`,
     );
     const data = await response.json();
     return data;
   }
 
+  // TODO: 캐시 처리
   async getSummonerSpellJson(): Promise<SummonerSpellJson> {
-    const latestVersion = await this.getLatestVersion();
+    const assetVersionedBaseUrl = await this.getAssetVersionedBaseUrl();
     const response = await fetch(
-      `${this.lolDataDragonBaseUrl}/cdn/${latestVersion}/data/ko_KR/summoner.json`,
+      `${assetVersionedBaseUrl}/data/${this.locale}/summoner.json`,
     );
     const data = await response.json();
     return data;
   }
 
+  // TODO: 캐시 처리
   async getRunesReforgedJson(): Promise<RunesReforgedJson> {
-    const latestVersion = await this.getLatestVersion();
+    const assetVersionedBaseUrl = await this.getAssetVersionedBaseUrl();
     const response = await fetch(
-      `${this.lolDataDragonBaseUrl}/cdn/${latestVersion}/data/ko_KR/runesReforged.json`,
+      `${assetVersionedBaseUrl}/data/${this.locale}/runesReforged.json`,
     );
     const data = await response.json();
     return data;

--- a/apps/api/src/riot/riot.service.ts
+++ b/apps/api/src/riot/riot.service.ts
@@ -5,7 +5,11 @@ import {
   CurrentGameNotFoundException,
   SummonerNotFoundException,
 } from '../exceptions/exceptions';
-import { SpectatorV5ResponseDto } from './riot.dto';
+import {
+  ChampionJson,
+  SpectatorV5ResponseDto,
+  SummonerSpellJson,
+} from './riot.dto';
 
 @Injectable()
 export class RiotService {
@@ -69,19 +73,35 @@ export class RiotService {
     }
   }
 
-  // 이후 사용
-  private async getAssetBaseUrl() {
+  async getAssetBaseUrl() {
     const latestVersion = await this.getLatestVersion();
 
-    return `${this.lolDataDragonBaseUrl}/cdn/${latestVersion}/data/ko_KR`;
+    return `${this.lolDataDragonBaseUrl}/cdn/${latestVersion}`;
   }
 
-  // 이후 사용
   private async getLatestVersion() {
     const versionResponse = await fetch(
       `${this.lolDataDragonBaseUrl}/api/versions.json`,
     );
     const data = await versionResponse.json();
     return data[0];
+  }
+
+  async getChampionJson(): Promise<ChampionJson> {
+    const latestVersion = await this.getLatestVersion();
+    const response = await fetch(
+      `${this.lolDataDragonBaseUrl}/cdn/${latestVersion}/data/ko_KR/champion.json`,
+    );
+    const data = await response.json();
+    return data;
+  }
+
+  async getSummonerSpellJson(): Promise<SummonerSpellJson> {
+    const latestVersion = await this.getLatestVersion();
+    const response = await fetch(
+      `${this.lolDataDragonBaseUrl}/cdn/${latestVersion}/data/ko_KR/summoner.json`,
+    );
+    const data = await response.json();
+    return data;
   }
 }

--- a/apps/api/src/riot/riot.service.ts
+++ b/apps/api/src/riot/riot.service.ts
@@ -7,6 +7,7 @@ import {
 } from '../exceptions/exceptions';
 import {
   ChampionJson,
+  RunesReforgedJson,
   SpectatorV5ResponseDto,
   SummonerSpellJson,
 } from './riot.dto';
@@ -74,6 +75,10 @@ export class RiotService {
   }
 
   async getAssetBaseUrl() {
+    return `${this.lolDataDragonBaseUrl}/cdn`;
+  }
+
+  async getAssetVersionedBaseUrl() {
     const latestVersion = await this.getLatestVersion();
 
     return `${this.lolDataDragonBaseUrl}/cdn/${latestVersion}`;
@@ -100,6 +105,15 @@ export class RiotService {
     const latestVersion = await this.getLatestVersion();
     const response = await fetch(
       `${this.lolDataDragonBaseUrl}/cdn/${latestVersion}/data/ko_KR/summoner.json`,
+    );
+    const data = await response.json();
+    return data;
+  }
+
+  async getRunesReforgedJson(): Promise<RunesReforgedJson> {
+    const latestVersion = await this.getLatestVersion();
+    const response = await fetch(
+      `${this.lolDataDragonBaseUrl}/cdn/${latestVersion}/data/ko_KR/runesReforged.json`,
     );
     const data = await response.json();
     return data;

--- a/apps/web/src/components/Player.tsx
+++ b/apps/web/src/components/Player.tsx
@@ -11,7 +11,7 @@ export function Player({ summoner }: PlayerProps) {
   return (
     <div className="grid grid-cols-[40px_200px_150px_120px_auto] items-center py-2 hover:bg-[#2a2a2a]">
       <img
-        src={`/images/champion/${summoner.championId}.png`}
+        src={summoner.champion.image.square}
         alt="champion"
         className="w-8 h-8 rounded-full"
       />

--- a/apps/web/src/components/Player.tsx
+++ b/apps/web/src/components/Player.tsx
@@ -16,10 +16,24 @@ export function Player({ summoner }: PlayerProps) {
         className="w-8 h-8 rounded-full"
       />
 
-      <div className="flex items-center gap-2">
-        {summoner.spells.map((spell) => (
-          <img src={spell.image.square} alt="perk" className="w-4 h-4" />
-        ))}
+      <div className="flex gap-2">
+        <div className="flex flex-col items-center gap-2">
+          {summoner.spells.map((spell) => (
+            <img src={spell.image.square} alt="perk" className="w-4 h-4" />
+          ))}
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <img
+            src={summoner.perks.perkStyle.image.square}
+            alt="perk"
+            className="w-4 h-4"
+          />
+          <img
+            src={summoner.perks.perkSubStyle.image.square}
+            alt="perk"
+            className="w-4 h-4"
+          />
+        </div>
       </div>
 
       <div className="flex items-center gap-1 text-nowrap">

--- a/apps/web/src/components/Player.tsx
+++ b/apps/web/src/components/Player.tsx
@@ -19,7 +19,12 @@ export function Player({ summoner }: PlayerProps) {
       <div className="flex gap-2">
         <div className="flex flex-col items-center gap-2">
           {summoner.spells.map((spell) => (
-            <img src={spell.image.square} alt="perk" className="w-4 h-4" />
+            <img
+              key={spell.id}
+              src={spell.image.square}
+              alt="perk"
+              className="w-4 h-4"
+            />
           ))}
         </div>
         <div className="flex flex-col items-center gap-2">

--- a/apps/web/src/components/Player.tsx
+++ b/apps/web/src/components/Player.tsx
@@ -17,16 +17,9 @@ export function Player({ summoner }: PlayerProps) {
       />
 
       <div className="flex items-center gap-2">
-        <img
-          src={`/images/perk/${summoner.perks.perkStyle}.png`}
-          alt="perk"
-          className="w-4 h-4"
-        />
-        <img
-          src={`/images/perk/${summoner.perks.perkSubStyle}.png`}
-          alt="perk"
-          className="w-4 h-4"
-        />
+        {summoner.spells.map((spell) => (
+          <img src={spell.image.square} alt="perk" className="w-4 h-4" />
+        ))}
       </div>
 
       <div className="flex items-center gap-1 text-nowrap">

--- a/packages/common-interfaces/package.json
+++ b/packages/common-interfaces/package.json
@@ -14,12 +14,12 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/types/index.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "@rollup/plugin-typescript": "^11.1.6",

--- a/packages/common-interfaces/rollup.config.js
+++ b/packages/common-interfaces/rollup.config.js
@@ -17,9 +17,16 @@ export default [
     plugins: [
       typescript({
         tsconfig: "./tsconfig.json",
-        declaration: true,
-        declarationDir: "./dist",
+        declaration: false,
       }),
     ],
+  },
+  {
+    input: "src/index.ts",
+    output: {
+      file: "dist/types/index.d.ts",
+      format: "esm",
+    },
+    plugins: [dts()],
   },
 ];

--- a/packages/common-interfaces/src/model/champion.ts
+++ b/packages/common-interfaces/src/model/champion.ts
@@ -1,0 +1,9 @@
+export interface Champion {
+  id: string;
+  key: string;
+  name: string;
+  title: string;
+  image: {
+    square: string;
+  };
+}

--- a/packages/common-interfaces/src/model/index.ts
+++ b/packages/common-interfaces/src/model/index.ts
@@ -4,3 +4,4 @@ export * from "./summoner";
 export * from "./banned-champion";
 export * from "./perks";
 export * from "./champion";
+export * from "./summoner-spell";

--- a/packages/common-interfaces/src/model/index.ts
+++ b/packages/common-interfaces/src/model/index.ts
@@ -3,3 +3,4 @@ export * from "./observer";
 export * from "./summoner";
 export * from "./banned-champion";
 export * from "./perks";
+export * from "./champion";

--- a/packages/common-interfaces/src/model/perks.ts
+++ b/packages/common-interfaces/src/model/perks.ts
@@ -1,5 +1,13 @@
 export interface Perks {
   perkIds: number[];
-  perkStyle: number;
-  perkSubStyle: number;
+  perkStyle: Perk;
+  perkSubStyle: Perk;
+}
+
+export interface Perk {
+  id: number;
+  name: string;
+  image: {
+    square: string;
+  };
 }

--- a/packages/common-interfaces/src/model/summoner-spell.ts
+++ b/packages/common-interfaces/src/model/summoner-spell.ts
@@ -1,0 +1,9 @@
+export interface SummonerSpell {
+  id: string;
+  name: string;
+  description: string;
+  key: string;
+  image: {
+    square: string;
+  };
+}

--- a/packages/common-interfaces/src/model/summoner.ts
+++ b/packages/common-interfaces/src/model/summoner.ts
@@ -1,12 +1,12 @@
 import { Champion } from "./champion";
 import { Perks } from "./perks";
+import { SummonerSpell } from "./summoner-spell";
 
 export interface Summoner {
   puuid: string;
   teamId: number;
-  spell1Id: number;
-  spell2Id: number;
   champion: Champion;
+  spells: SummonerSpell[];
   profileIconId: number;
   riotId: string;
   bot: boolean;

--- a/packages/common-interfaces/src/model/summoner.ts
+++ b/packages/common-interfaces/src/model/summoner.ts
@@ -1,3 +1,4 @@
+import { Champion } from "./champion";
 import { Perks } from "./perks";
 
 export interface Summoner {
@@ -5,7 +6,7 @@ export interface Summoner {
   teamId: number;
   spell1Id: number;
   spell2Id: number;
-  championId: number;
+  champion: Champion;
   profileIconId: number;
   riotId: string;
   bot: boolean;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 플레이어 정보 화면이 개선되어, 챔피언 이미지와 주문(스펠) 아이콘이 동적으로 렌더링됩니다.
  - 업데이트된 데이터 매핑으로 더 정확하고 일관된 챔피언 및 주문 정보가 제공됩니다.
  - 새로운 인터페이스가 추가되어 챔피언 및 주문 스펠의 구조가 명확해졌습니다.
  - 매퍼 서비스가 초기화 로직과 데이터 변환 프로세스를 도입하여 기능이 향상되었습니다.
  - RiotService에 새로운 메서드가 추가되어 JSON 데이터를 동적으로 가져올 수 있게 되었습니다.
  - 새로운 예외 클래스가 추가되어 챔피언, 주문 스펠, 및 특성 관련 오류 처리가 개선되었습니다.
- **Bug Fixes**
  - 챔피언 및 주문 스펠의 이미지 접근 방식이 개선되어 오류가 줄어들었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->